### PR TITLE
add error field to graphql exception response

### DIFF
--- a/src/ring/middleware/exceptions.clj
+++ b/src/ring/middleware/exceptions.clj
@@ -32,6 +32,7 @@
                (-> e ex-data :http-status)
                200)
    :body {:errors [{:message (.getMessage e)
+                    :error (-> e ex-data :error)
                     :error-id id}]}})
 
 (defn sql-exception-response


### PR DESCRIPTION
Some third-party APIs return something called error code, for example, [Common Errors for Agora Cloud Recording API](https://docs.agora.io/en/cloud-recording/common_errors?platform=All%20Platforms). For graphql API wrapper, it might be convenient to also expose the error code in the exception response.